### PR TITLE
fix: deposit status overwritten to pending

### DIFF
--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -12,6 +12,7 @@ import type {
 import type { SubstrateBatchProcessor } from "@subsquid/substrate-processor";
 import type { Store } from "@subsquid/typeorm-store";
 import { TypeormDatabase } from "@subsquid/typeorm-store";
+import { In } from "typeorm";
 
 import {
   Transfer,
@@ -155,6 +156,17 @@ export class Indexer {
         transfers.set(d.id, transfer);
       }
     }
+
+    const existingTransfers: Transfer[] = await ctx.store.findBy(Transfer, {
+      id: In(Array.from(transfers.keys())),
+    });
+
+    for (const existingTransfer of existingTransfers) {
+      const transfer = transfers.get(existingTransfer.id);
+      transfer!.status = TransferStatus.executed;
+      transfers.set(existingTransfer.id, transfer!);
+    }
+
     await ctx.store.upsert([...deposits.values()]);
     await ctx.store.upsert([...transfers.values()]);
   }


### PR DESCRIPTION
In some cases `execution` will be caught before `deposit` so the additional code makes sure that the transfer status isn't overwritten to `pending`. 