### PR TITLE
chore: Add routes endpoint

### DIFF
--- a/src/api/controllers/RoutesController.ts
+++ b/src/api/controllers/RoutesController.ts
@@ -1,0 +1,32 @@
+/*
+The Licensed Work is (c) 2024 Sygma
+SPDX-License-Identifier: LGPL-3.0-only
+*/
+import type { FastifyReply, FastifyRequest } from "fastify";
+import type { DataSource, FindOptionsWhere } from "typeorm";
+
+import type { Route } from "../../model";
+import { logger } from "../../utils/logger";
+import { RoutesService } from "../services/dataAccess/routes.service";
+
+export class RoutesController {
+  private routesService: RoutesService;
+
+  constructor(dataSource: DataSource) {
+    this.routesService = new RoutesService(dataSource);
+  }
+
+  public async getRoutes(
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ): Promise<void> {
+    try {
+      const where: FindOptionsWhere<Route> = {};
+      const routesResult = await this.routesService.findRoutes(where);
+      await reply.status(200).send(routesResult);
+    } catch (error) {
+      logger.error("Error occurred when fetching transfers", error);
+      await reply.status(500).send({ error: "Internal server error" });
+    }
+  }
+}

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -4,8 +4,10 @@ SPDX-License-Identifier: LGPL-3.0-only
 */
 import type { FastifyInstance } from "fastify";
 
+import { routeEntityRoutes } from "./routeEntity.routes";
 import { transferRoutes } from "./transfers.routes";
 
 export async function registerRoutes(server: FastifyInstance): Promise<void> {
   await server.register(transferRoutes, { prefix: "/api" });
+  await server.register(routeEntityRoutes, { prefix: "/api" });
 }

--- a/src/api/routes/routeEntity.routes.ts
+++ b/src/api/routes/routeEntity.routes.ts
@@ -1,0 +1,20 @@
+/*
+The Licensed Work is (c) 2024 Sygma
+SPDX-License-Identifier: LGPL-3.0-only
+*/
+import type { FastifyInstance } from "fastify";
+
+import { RoutesController } from "../controllers/RoutesController";
+import { routesSchema } from "../schemas/routes.schema";
+
+export async function routeEntityRoutes(
+  server: FastifyInstance,
+): Promise<void> {
+  const routesController = new RoutesController(server.db);
+  server.get(
+    "/routes",
+    { schema: routesSchema },
+    routesController.getRoutes.bind(routesController),
+  );
+  return Promise.resolve();
+}

--- a/src/api/schemas/index.ts
+++ b/src/api/schemas/index.ts
@@ -152,6 +152,27 @@ export const executionSchema = {
   },
 };
 
+export const routeSchema = {
+  properties: {
+    id: {
+      type: "string",
+      format: "ObjectId",
+      example: "1ffe10e3-c16c-4fdb-a357-380accf1eb66",
+    },
+    fromDomainID: { type: "string", example: "1" },
+    fromDomain: { ...domainSchema },
+    toDomainID: { type: "string", nullable: true, example: "2" },
+    toDomain: { ...domainSchema },
+    resourceID: {
+      type: "string",
+      format: "ObjectId",
+      example:
+        "0x0000000000000000000000000000000000000000000000000000000000000300",
+    },
+    resource: { ...resourceSchema },
+  },
+};
+
 export const transferSchema = {
   type: "object",
   properties: {

--- a/src/api/schemas/routes.schema.ts
+++ b/src/api/schemas/routes.schema.ts
@@ -1,0 +1,24 @@
+/*
+The Licensed Work is (c) 2024 Sygma
+SPDX-License-Identifier: LGPL-3.0-only
+*/
+import { routeSchema } from ".";
+
+export const routesSchema = {
+  summary: "Get routes",
+  response: {
+    200: {
+      description: "List of routes",
+      content: {
+        "application/json": {
+          schema: {
+            type: "array",
+            items: {
+              ...routeSchema,
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/api/services/dataAccess/routes.service.ts
+++ b/src/api/services/dataAccess/routes.service.ts
@@ -1,0 +1,32 @@
+/*
+The Licensed Work is (c) 2024 Sygma
+SPDX-License-Identifier: LGPL-3.0-only
+*/
+import type { DataSource, FindOptionsWhere, Repository } from "typeorm";
+
+import { Route } from "../../../model";
+
+export class RoutesService {
+  private routeRepository: Repository<Route>;
+  constructor(dataSource: DataSource) {
+    this.routeRepository = dataSource.getRepository(Route);
+  }
+
+  public async findRoutes(where: FindOptionsWhere<Route>): Promise<Route[]> {
+    const routes = await this.routeRepository.find({
+      where,
+      order: {
+        fromDomainID: "ASC",
+        toDomainID: "ASC",
+        resourceID: "ASC", 
+      },
+      relations: {
+        fromDomain: true,
+        toDomain: true,
+        // resource: true,
+      },
+    });
+
+    return routes;
+  }
+}


### PR DESCRIPTION
Added `/routes` endpoint for fetching all routes. 

closes #22 